### PR TITLE
Fix array elements

### DIFF
--- a/dist/DynamicFormBuilder.js
+++ b/dist/DynamicFormBuilder.js
@@ -458,6 +458,10 @@ function (_React$Component) {
   }, {
     key: "renderLabel",
     value: function renderLabel(input) {
+      if (!input.label) {
+        return;
+      }
+
       var props = {
         className: this.props.classPrefix + '-' + (input.label.className || this.props.defaultLabelClass || ''),
         htmlFor: input.name

--- a/src/DynamicFormBuilder.jsx
+++ b/src/DynamicFormBuilder.jsx
@@ -341,6 +341,10 @@ class DynamicFormBuilder extends React.Component {
     }
 
     renderLabel(input) {
+        if (!input.label) {
+            return;
+        }
+
         const props = {
             className: this.props.classPrefix + '-' + (input.label.className || this.props.defaultLabelClass || ''),
             htmlFor: input.name


### PR DESCRIPTION
Seems like `renderLabel` gets called even with array elements. This checks that `input.label` is not falsey before building the props.

```js
const form = {
  [ // Still attempts to render label
    { name: 'first_name' },
    { name: 'last_name' }
  ]
}
```