### PR TITLE
Ensure prop errors are passed to custom inputs

### DIFF
--- a/dist/DynamicFormBuilder.js
+++ b/dist/DynamicFormBuilder.js
@@ -374,6 +374,13 @@ function (_React$Component) {
       return !invalid;
     }
   }, {
+    key: "getInputValidationError",
+    value: function getInputValidationError(inputName) {
+      var validationError = this.state.validation_errors[inputName];
+      var propError = this.props.formErrors[inputName];
+      return validationError && validationError !== true ? validationError : propError;
+    }
+  }, {
     key: "submitForm",
     value: function submitForm() {
       if (this.props.onSubmit) {
@@ -405,11 +412,11 @@ function (_React$Component) {
           value: this.state.form[input.name] || '',
           onChange: this.handleBlur.bind(this, input),
           onBlur: this.handleBlur.bind(this, input),
-          invalid: !!this.state.validation_errors[input.name] || undefined
+          invalid: !!this.getInputValidationError(input.name) || undefined
         });
       }
 
-      return input.render(input, this.state.form[input.name] || '', this.handleInput.bind(this, input), this.handleBlur.bind(this, input), this.state.validation_errors[input.name], this.state);
+      return input.render(input, this.state.form[input.name] || '', this.handleInput.bind(this, input), this.handleBlur.bind(this, input), this.getInputValidationError(input.name), this.state);
     }
   }, {
     key: "renderInput",
@@ -502,7 +509,7 @@ function (_React$Component) {
   }, {
     key: "renderValidationErrors",
     value: function renderValidationErrors(input) {
-      var validationError = this.state.validation_errors[input.name] && this.state.validation_errors[input.name] !== true ? this.state.validation_errors[input.name] : this.props.formErrors[input.name];
+      var validationError = this.getInputValidationError(input.name);
 
       if (validationError) {
         return _react.default.createElement("p", {

--- a/dist/DynamicFormBuilder.js
+++ b/dist/DynamicFormBuilder.js
@@ -379,8 +379,10 @@ function (_React$Component) {
   }, {
     key: "getInputValidationError",
     value: function getInputValidationError(inputName) {
-      var validationError = this.state.validation_errors[inputName];
-      var propError = this.props.formErrors[inputName];
+      var validationErrors = this.state.validationErrors;
+      var formErrors = this.props.formErrors;
+      var validationError = validationErrors[inputName];
+      var propError = formErrors[inputName];
       return validationError && validationError !== true ? validationError : propError;
     }
   }, {

--- a/src/DynamicFormBuilder.jsx
+++ b/src/DynamicFormBuilder.jsx
@@ -468,7 +468,7 @@ class DynamicFormBuilder extends React.Component {
         const { classPrefix, defaultValidationErrorClass, formErrors } = this.props;
 
         const validationError = this.getInputValidationError(input.name);
-        
+
         if (validationError) {
             return (
                 <p className={`${classPrefix}-${defaultValidationErrorClass || ''}`}>

--- a/src/DynamicFormBuilder.jsx
+++ b/src/DynamicFormBuilder.jsx
@@ -261,6 +261,13 @@ class DynamicFormBuilder extends React.Component {
         return !invalid;
     }
 
+    getInputValidationError(inputName) {
+        const validationError = this.state.validation_errors[inputName];
+        const propError = this.props.formErrors[inputName];
+        
+        return (validationError && validationError !== true) ? validationError : propError;
+    }
+    
     submitForm() {
         if (this.props.onSubmit) {
 
@@ -291,7 +298,7 @@ class DynamicFormBuilder extends React.Component {
                         value: this.state.form[input.name] || '',
                         onChange: this.handleBlur.bind(this, input),
                         onBlur: this.handleBlur.bind(this, input),
-                        invalid: !!this.state.validation_errors[input.name] || undefined
+                        invalid: !!this.getInputValidationError(input.name) || undefined
                     }
                 )
             );
@@ -302,7 +309,7 @@ class DynamicFormBuilder extends React.Component {
             this.state.form[input.name] || '',
             this.handleInput.bind(this, input),
             this.handleBlur.bind(this, input),
-            this.state.validation_errors[input.name],
+            this.getInputValidationError(input.name),
             this.state
         );
     }
@@ -399,7 +406,7 @@ class DynamicFormBuilder extends React.Component {
     }
 
     renderValidationErrors(input) {
-        const validationError = (this.state.validation_errors[input.name] && this.state.validation_errors[input.name] !== true) ? this.state.validation_errors[input.name] : this.props.formErrors[input.name];
+        const validationError = this.getInputValidationError(input.name);
         if (validationError) {
             return (
                 <p className={`${this.props.classPrefix}-${this.props.defaultValidationErrorClass || ''}`}>{validationError}</p>

--- a/src/DynamicFormBuilder.jsx
+++ b/src/DynamicFormBuilder.jsx
@@ -288,8 +288,11 @@ class DynamicFormBuilder extends React.Component {
     }
 
     getInputValidationError(inputName) {
-        const validationError = this.state.validation_errors[inputName];
-        const propError = this.props.formErrors[inputName];
+        const { validationErrors } = this.state;
+        const { formErrors } = this.props;
+      
+        const validationError = validationErrors[inputName];
+        const propError = formErrors[inputName];
         
         return (validationError && validationError !== true) ? validationError : propError;
     }


### PR DESCRIPTION
This commit ensures that custom prop based validation errors are passed to custom rendered inputs. Previously only the validation errors stored in the form builders state were considered.