### PR TITLE
Use propagateChange rather than directly setting state

### DIFF
--- a/dist/DynamicFormBuilder.js
+++ b/dist/DynamicFormBuilder.js
@@ -134,8 +134,6 @@ function (_React$Component) {
       var pValues = this.props.values;
 
       if (pValues) {
-        console.log(JSON.stringify(pValues) !== JSON.stringify(ppValues));
-
         if (JSON.stringify(pValues) !== JSON.stringify(ppValues)) {
           var form = _objectSpread({}, ppValues, pValues);
 

--- a/dist/DynamicFormBuilder.js
+++ b/dist/DynamicFormBuilder.js
@@ -132,8 +132,6 @@ function (_React$Component) {
     value: function componentDidUpdate(prevProps) {
       var ppValues = prevProps.values;
       var pValues = this.props.values;
-      console.log('prev %O', ppValues, ppValues.distance);
-      console.log('props %O', pValues, pValues.distance);
 
       if (pValues) {
         console.log(JSON.stringify(pValues) !== JSON.stringify(ppValues));
@@ -286,9 +284,7 @@ function (_React$Component) {
     value: function propagateChange(form, validationErrors) {
       var _this3 = this;
 
-      var _this$props = this.props,
-          values = _this$props.values,
-          onChange = _this$props.onChange;
+      var onChange = this.props.onChange;
 
       var callback = function callback() {
         return onChange({
@@ -432,9 +428,7 @@ function (_React$Component) {
   }, {
     key: "renderCustomInput",
     value: function renderCustomInput(input) {
-      var _this$state2 = this.state,
-          form = _this$state2.form,
-          validationErrors = _this$state2.validationErrors;
+      var form = this.state.form;
 
       if (typeof input.render !== 'function') {
         if (!_react.default.isValidElement(input.render)) {
@@ -462,15 +456,15 @@ function (_React$Component) {
         return this.renderInputs(input);
       }
 
-      var _this$state3 = this.state,
-          form = _this$state3.form,
-          validationErrors = _this$state3.validationErrors;
-      var _this$props2 = this.props,
-          formErrors = _this$props2.formErrors,
-          classPrefix = _this$props2.classPrefix,
-          defaultInputClass = _this$props2.defaultInputClass,
-          invalidInputClass = _this$props2.invalidInputClass,
-          validInputClass = _this$props2.validInputClass;
+      var _this$state2 = this.state,
+          form = _this$state2.form,
+          validationErrors = _this$state2.validationErrors;
+      var _this$props = this.props,
+          formErrors = _this$props.formErrors,
+          classPrefix = _this$props.classPrefix,
+          defaultInputClass = _this$props.defaultInputClass,
+          invalidInputClass = _this$props.invalidInputClass,
+          validInputClass = _this$props.validInputClass;
 
       if (input.render) {
         return this.renderCustomInput(input);
@@ -538,9 +532,9 @@ function (_React$Component) {
         return;
       }
 
-      var _this$props3 = this.props,
-          classPrefix = _this$props3.classPrefix,
-          defaultLabelClass = _this$props3.defaultLabelClass;
+      var _this$props2 = this.props,
+          classPrefix = _this$props2.classPrefix,
+          defaultLabelClass = _this$props2.defaultLabelClass;
       var props = {
         className: classPrefix + '-' + (input.label.className || defaultLabelClass || ''),
         htmlFor: input.name
@@ -558,10 +552,10 @@ function (_React$Component) {
     key: "renderValidationErrors",
     value: function renderValidationErrors(input) {
       var validationErrors = this.state.validationErrors;
-      var _this$props4 = this.props,
-          classPrefix = _this$props4.classPrefix,
-          defaultValidationErrorClass = _this$props4.defaultValidationErrorClass,
-          formErrors = _this$props4.formErrors;
+      var _this$props3 = this.props,
+          classPrefix = _this$props3.classPrefix,
+          defaultValidationErrorClass = _this$props3.defaultValidationErrorClass,
+          formErrors = _this$props3.formErrors;
       var validationError = this.getInputValidationError(input.name);
 
       if (validationError) {
@@ -573,11 +567,11 @@ function (_React$Component) {
   }, {
     key: "renderSubmitButton",
     value: function renderSubmitButton() {
-      var _this$props5 = this.props,
-          submitButton = _this$props5.submitButton,
-          classPrefix = _this$props5.classPrefix,
-          defaultSubmitClass = _this$props5.defaultSubmitClass,
-          loading = _this$props5.loading;
+      var _this$props4 = this.props,
+          submitButton = _this$props4.submitButton,
+          classPrefix = _this$props4.classPrefix,
+          defaultSubmitClass = _this$props4.defaultSubmitClass,
+          loading = _this$props4.loading;
 
       if (submitButton) {
         return _react.default.createElement("button", {
@@ -589,10 +583,10 @@ function (_React$Component) {
   }, {
     key: "renderSubmitButtonContents",
     value: function renderSubmitButtonContents() {
-      var _this$props6 = this.props,
-          submitButton = _this$props6.submitButton,
-          loading = _this$props6.loading,
-          loadingElement = _this$props6.loadingElement;
+      var _this$props5 = this.props,
+          submitButton = _this$props5.submitButton,
+          loading = _this$props5.loading,
+          loadingElement = _this$props5.loadingElement;
 
       if (loading && loadingElement) {
         return loadingElement;
@@ -605,9 +599,9 @@ function (_React$Component) {
     value: function renderInputs(inputs) {
       var _this7 = this;
 
-      var _this$props7 = this.props,
-          classPrefix = _this$props7.classPrefix,
-          defaultContainerClass = _this$props7.defaultContainerClass;
+      var _this$props6 = this.props,
+          classPrefix = _this$props6.classPrefix,
+          defaultContainerClass = _this$props6.defaultContainerClass;
       return _react.default.createElement(_react.Fragment, null, inputs.map(function (input, i) {
         var isArray = input.constructor === Array;
         var containerClass = isArray ? "".concat(classPrefix, "-row") : "".concat(classPrefix, "-").concat(input.containerClass || defaultContainerClass || '');

--- a/dist/DynamicFormBuilder.js
+++ b/dist/DynamicFormBuilder.js
@@ -129,13 +129,17 @@ function (_React$Component) {
 
   _createClass(DynamicFormBuilder, [{
     key: "componentDidUpdate",
-    value: function componentDidUpdate(_, state) {
-      var sValues = state.form;
+    value: function componentDidUpdate(prevProps) {
+      var ppValues = prevProps.values;
       var pValues = this.props.values;
+      console.log('prev %O', ppValues, ppValues.distance);
+      console.log('props %O', pValues, pValues.distance);
 
       if (pValues) {
-        if (JSON.stringify(pValues) !== JSON.stringify(sValues)) {
-          var form = _objectSpread({}, sValues, pValues);
+        console.log(JSON.stringify(pValues) !== JSON.stringify(ppValues));
+
+        if (JSON.stringify(pValues) !== JSON.stringify(ppValues)) {
+          var form = _objectSpread({}, ppValues, pValues);
 
           this.propagateChange(form);
         }
@@ -282,20 +286,23 @@ function (_React$Component) {
     value: function propagateChange(form, validationErrors) {
       var _this3 = this;
 
-      var onChange = this.props.onChange;
+      var _this$props = this.props,
+          values = _this$props.values,
+          onChange = _this$props.onChange;
+
+      var callback = function callback() {
+        return onChange({
+          valid: _this3.validateForm(false),
+          data: {
+            form: form,
+            validationErrors: validationErrors
+          }
+        });
+      };
+
       this.setState({
         form: _objectSpread({}, form)
-      }, function () {
-        if (onChange) {
-          onChange({
-            valid: _this3.validateForm(false),
-            data: {
-              form: form,
-              validationErrors: validationErrors
-            }
-          });
-        }
-      });
+      }, callback);
     }
   }, {
     key: "handleInput",
@@ -458,12 +465,12 @@ function (_React$Component) {
       var _this$state3 = this.state,
           form = _this$state3.form,
           validationErrors = _this$state3.validationErrors;
-      var _this$props = this.props,
-          formErrors = _this$props.formErrors,
-          classPrefix = _this$props.classPrefix,
-          defaultInputClass = _this$props.defaultInputClass,
-          invalidInputClass = _this$props.invalidInputClass,
-          validInputClass = _this$props.validInputClass;
+      var _this$props2 = this.props,
+          formErrors = _this$props2.formErrors,
+          classPrefix = _this$props2.classPrefix,
+          defaultInputClass = _this$props2.defaultInputClass,
+          invalidInputClass = _this$props2.invalidInputClass,
+          validInputClass = _this$props2.validInputClass;
 
       if (input.render) {
         return this.renderCustomInput(input);
@@ -531,9 +538,9 @@ function (_React$Component) {
         return;
       }
 
-      var _this$props2 = this.props,
-          classPrefix = _this$props2.classPrefix,
-          defaultLabelClass = _this$props2.defaultLabelClass;
+      var _this$props3 = this.props,
+          classPrefix = _this$props3.classPrefix,
+          defaultLabelClass = _this$props3.defaultLabelClass;
       var props = {
         className: classPrefix + '-' + (input.label.className || defaultLabelClass || ''),
         htmlFor: input.name
@@ -551,10 +558,10 @@ function (_React$Component) {
     key: "renderValidationErrors",
     value: function renderValidationErrors(input) {
       var validationErrors = this.state.validationErrors;
-      var _this$props3 = this.props,
-          classPrefix = _this$props3.classPrefix,
-          defaultValidationErrorClass = _this$props3.defaultValidationErrorClass,
-          formErrors = _this$props3.formErrors;
+      var _this$props4 = this.props,
+          classPrefix = _this$props4.classPrefix,
+          defaultValidationErrorClass = _this$props4.defaultValidationErrorClass,
+          formErrors = _this$props4.formErrors;
       var validationError = this.getInputValidationError(input.name);
 
       if (validationError) {
@@ -566,11 +573,11 @@ function (_React$Component) {
   }, {
     key: "renderSubmitButton",
     value: function renderSubmitButton() {
-      var _this$props4 = this.props,
-          submitButton = _this$props4.submitButton,
-          classPrefix = _this$props4.classPrefix,
-          defaultSubmitClass = _this$props4.defaultSubmitClass,
-          loading = _this$props4.loading;
+      var _this$props5 = this.props,
+          submitButton = _this$props5.submitButton,
+          classPrefix = _this$props5.classPrefix,
+          defaultSubmitClass = _this$props5.defaultSubmitClass,
+          loading = _this$props5.loading;
 
       if (submitButton) {
         return _react.default.createElement("button", {
@@ -582,10 +589,10 @@ function (_React$Component) {
   }, {
     key: "renderSubmitButtonContents",
     value: function renderSubmitButtonContents() {
-      var _this$props5 = this.props,
-          submitButton = _this$props5.submitButton,
-          loading = _this$props5.loading,
-          loadingElement = _this$props5.loadingElement;
+      var _this$props6 = this.props,
+          submitButton = _this$props6.submitButton,
+          loading = _this$props6.loading,
+          loadingElement = _this$props6.loadingElement;
 
       if (loading && loadingElement) {
         return loadingElement;
@@ -598,9 +605,9 @@ function (_React$Component) {
     value: function renderInputs(inputs) {
       var _this7 = this;
 
-      var _this$props6 = this.props,
-          classPrefix = _this$props6.classPrefix,
-          defaultContainerClass = _this$props6.defaultContainerClass;
+      var _this$props7 = this.props,
+          classPrefix = _this$props7.classPrefix,
+          defaultContainerClass = _this$props7.defaultContainerClass;
       return _react.default.createElement(_react.Fragment, null, inputs.map(function (input, i) {
         var isArray = input.constructor === Array;
         var containerClass = isArray ? "".concat(classPrefix, "-row") : "".concat(classPrefix, "-").concat(input.containerClass || defaultContainerClass || '');
@@ -641,7 +648,10 @@ DynamicFormBuilder.defaultProps = {
   loading: false,
   loadingElement: null,
   formErrors: {},
-  validationTimeout: 1000
+  validationTimeout: 1000,
+  onChange: function onChange() {
+    return null;
+  }
 };
 DynamicFormBuilder.propTypes = {
   defaultValues: _propTypes.default.object,
@@ -659,7 +669,8 @@ DynamicFormBuilder.propTypes = {
   invalidInputClass: _propTypes.default.string,
   validInputClass: _propTypes.default.string,
   loadingElement: _propTypes.default.element,
-  formErrors: _propTypes.default.object
+  formErrors: _propTypes.default.object,
+  onChange: _propTypes.default.func
 };
 var _default = DynamicFormBuilder;
 exports.default = _default;

--- a/dist/DynamicFormBuilder.js
+++ b/dist/DynamicFormBuilder.js
@@ -19,11 +19,7 @@ require("core-js/modules/es6.object.create");
 
 require("core-js/modules/es6.object.set-prototype-of");
 
-require("core-js/modules/es6.array.iterator");
-
 require("core-js/modules/es6.array.map");
-
-require("core-js/modules/web.dom.iterable");
 
 require("core-js/modules/es6.array.for-each");
 
@@ -34,6 +30,10 @@ require("core-js/modules/es6.function.name");
 require("core-js/modules/es6.array.filter");
 
 require("core-js/modules/es6.regexp.constructor");
+
+require("core-js/modules/web.dom.iterable");
+
+require("core-js/modules/es6.array.iterator");
 
 require("core-js/modules/es6.function.bind");
 
@@ -128,6 +128,22 @@ function (_React$Component) {
   }
 
   _createClass(DynamicFormBuilder, [{
+    key: "componentDidUpdate",
+    value: function componentDidUpdate(_, state) {
+      var sValues = state.form;
+      var pValues = this.props.values;
+
+      if (pValues) {
+        if (JSON.stringify(pValues) !== JSON.stringify(sValues)) {
+          var form = _objectSpread({}, sValues, pValues);
+
+          this.propagateChange(form);
+        }
+      }
+
+      return null;
+    }
+  }, {
     key: "applyFilter",
     value: function applyFilter(event, filter) {
       switch (filter.constructor) {
@@ -268,7 +284,7 @@ function (_React$Component) {
 
       var onChange = this.props.onChange;
       this.setState({
-        form: form
+        form: _objectSpread({}, form)
       }, function () {
         if (onChange) {
           onChange({
@@ -604,22 +620,6 @@ function (_React$Component) {
         console.error(e);
         return _react.default.createElement("p", null, "Error rendering form");
       }
-    }
-  }], [{
-    key: "getDerivedStateFromProps",
-    value: function getDerivedStateFromProps(props, state) {
-      var sValues = state.form;
-      var pValues = props.values;
-
-      if (pValues) {
-        if (JSON.stringify(pValues) !== JSON.stringify(sValues)) {
-          return _objectSpread({}, state, {
-            form: _objectSpread({}, sValues, pValues)
-          });
-        }
-      }
-
-      return null;
     }
   }]);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-form-builder",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A form builder for React that allows input filters, transformers and validators as well as custom input rendering",
   "main": "dist/DynamicFormBuilder.js",
   "scripts": {

--- a/src/DynamicFormBuilder.jsx
+++ b/src/DynamicFormBuilder.jsx
@@ -45,14 +45,18 @@ class DynamicFormBuilder extends React.Component {
         this.propagateChange = this.propagateChange.bind(this);
     }
 
-    componentDidUpdate(_, state) {
-        const { form: sValues } = state
+    componentDidUpdate(prevProps) {
+        const { values: ppValues } = prevProps
         const { values: pValues } = this.props
 
+        console.log('prev %O', ppValues, ppValues.distance)
+        console.log('props %O', pValues, pValues.distance)
+
         if (pValues) {
-            if (JSON.stringify(pValues) !== JSON.stringify(sValues)) {
+            console.log(JSON.stringify(pValues) !== JSON.stringify(ppValues))
+            if (JSON.stringify(pValues) !== JSON.stringify(ppValues)) {
                 const form = {
-                    ...sValues, ...pValues
+                    ...ppValues, ...pValues
                 };
 
                 this.propagateChange(form);
@@ -190,21 +194,21 @@ class DynamicFormBuilder extends React.Component {
     }
 
     propagateChange(form, validationErrors) {
-        const { onChange } = this.props;
+        const { values, onChange } = this.props;
+
+        const callback = () => (
+            onChange({
+                valid: this.validateForm(false),
+                data: {
+                    form,
+                    validationErrors,
+                },
+            })
+        );
 
         this.setState(
             { form: { ...form } },
-            () => {
-                if (onChange) {
-                    onChange({
-                        valid: this.validateForm(false),
-                        data: {
-                            form,
-                            validationErrors,
-                        },
-                    });
-                }
-            }
+            callback
         );
     }
 
@@ -579,6 +583,7 @@ DynamicFormBuilder.defaultProps = {
     loadingElement: null,
     formErrors: {},
     validationTimeout: 1000,
+    onChange: () => null,
 };
 
 DynamicFormBuilder.propTypes = {
@@ -598,6 +603,7 @@ DynamicFormBuilder.propTypes = {
     validInputClass: PropTypes.string,
     loadingElement: PropTypes.element,
     formErrors: PropTypes.object,
+    onChange: PropTypes.func,
 };
 
 export default DynamicFormBuilder;

--- a/src/DynamicFormBuilder.jsx
+++ b/src/DynamicFormBuilder.jsx
@@ -49,9 +49,6 @@ class DynamicFormBuilder extends React.Component {
         const { values: ppValues } = prevProps
         const { values: pValues } = this.props
 
-        console.log('prev %O', ppValues, ppValues.distance)
-        console.log('props %O', pValues, pValues.distance)
-
         if (pValues) {
             console.log(JSON.stringify(pValues) !== JSON.stringify(ppValues))
             if (JSON.stringify(pValues) !== JSON.stringify(ppValues)) {
@@ -194,7 +191,7 @@ class DynamicFormBuilder extends React.Component {
     }
 
     propagateChange(form, validationErrors) {
-        const { values, onChange } = this.props;
+        const { onChange } = this.props;
 
         const callback = () => (
             onChange({
@@ -336,7 +333,7 @@ class DynamicFormBuilder extends React.Component {
     }
 
     renderCustomInput(input) {
-        const { form, validationErrors } = this.state;
+        const { form } = this.state;
 
         if (typeof input.render !== 'function') {
             if (!React.isValidElement(input.render)) {

--- a/src/DynamicFormBuilder.jsx
+++ b/src/DynamicFormBuilder.jsx
@@ -45,16 +45,17 @@ class DynamicFormBuilder extends React.Component {
         this.propagateChange = this.propagateChange.bind(this);
     }
 
-    static getDerivedStateFromProps(props, state) {
+    componentDidUpdate(_, state) {
         const { form: sValues } = state
-        const { values: pValues } = props
+        const { values: pValues } = this.props
 
         if (pValues) {
             if (JSON.stringify(pValues) !== JSON.stringify(sValues)) {
-                return {
-                    ...state,
-                    form: { ...sValues, ...pValues },
+                const form = {
+                    ...sValues, ...pValues
                 };
+
+                this.propagateChange(form);
             }
         }
 
@@ -192,7 +193,7 @@ class DynamicFormBuilder extends React.Component {
         const { onChange } = this.props;
 
         this.setState(
-            { form },
+            { form: { ...form } },
             () => {
                 if (onChange) {
                     onChange({

--- a/src/DynamicFormBuilder.jsx
+++ b/src/DynamicFormBuilder.jsx
@@ -50,7 +50,6 @@ class DynamicFormBuilder extends React.Component {
         const { values: pValues } = this.props
 
         if (pValues) {
-            console.log(JSON.stringify(pValues) !== JSON.stringify(ppValues))
             if (JSON.stringify(pValues) !== JSON.stringify(ppValues)) {
                 const form = {
                     ...ppValues, ...pValues


### PR DESCRIPTION
This fixes an issue where values being passed in would not _actually_ update the output of the form. Calling `propagateChange` triggers the same process as if an input changes from the user.