### PR TITLE
Fix validation spread

### DIFF
--- a/dist/DynamicFormBuilder.js
+++ b/dist/DynamicFormBuilder.js
@@ -73,11 +73,11 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 var DynamicFormBuilder =
 /*#__PURE__*/
@@ -121,9 +121,9 @@ function (_React$Component) {
         return /^$|^\d+$|^\.\d+|^\d+\.\d+$/.test(value);
       }
     };
-    _this.validateForm = _this.validateForm.bind(_assertThisInitialized(_assertThisInitialized(_this)));
-    _this.submitForm = _this.submitForm.bind(_assertThisInitialized(_assertThisInitialized(_this)));
-    _this.propagateChange = _this.propagateChange.bind(_assertThisInitialized(_assertThisInitialized(_this)));
+    _this.validateForm = _this.validateForm.bind(_assertThisInitialized(_this));
+    _this.submitForm = _this.submitForm.bind(_assertThisInitialized(_this));
+    _this.propagateChange = _this.propagateChange.bind(_assertThisInitialized(_this));
     return _this;
   }
 
@@ -285,8 +285,14 @@ function (_React$Component) {
       var onChange = this.props.onChange;
 
       var callback = function callback() {
-        return onChange({
-          valid: _this3.validateForm(false),
+        var _this3$validateForm = _this3.validateForm(),
+            _this3$validateForm2 = _slicedToArray(_this3$validateForm, 2),
+            valid = _this3$validateForm2[0],
+            errors = _this3$validateForm2[1];
+
+        validationErrors = validationErrors || errors;
+        onChange({
+          valid: valid,
           data: {
             form: form,
             validationErrors: validationErrors
@@ -377,7 +383,7 @@ function (_React$Component) {
             valid = _this5$validateInput2[0],
             validationError = _this5$validateInput2[1];
 
-        validationErrors = _objectSpread({}, validationError);
+        validationErrors = _objectSpread({}, validationErrors, validationError);
 
         if (!valid) {
           invalid = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-form-builder",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A form builder for React that allows input filters, transformers and validators as well as custom input rendering",
   "main": "dist/DynamicFormBuilder.js",
   "scripts": {

--- a/src/DynamicFormBuilder.jsx
+++ b/src/DynamicFormBuilder.jsx
@@ -192,15 +192,19 @@ class DynamicFormBuilder extends React.Component {
     propagateChange(form, validationErrors) {
         const { onChange } = this.props;
 
-        const callback = () => (
+        const callback = () => {
+            const [ valid, errors ] = this.validateForm()
+
+            validationErrors = validationErrors || errors
+
             onChange({
-                valid: this.validateForm(false),
+                valid,
                 data: {
                     form,
                     validationErrors,
                 },
             })
-        );
+        };
 
         this.setState(
             { form: { ...form } },
@@ -285,6 +289,7 @@ class DynamicFormBuilder extends React.Component {
                 this.validateInput(input.name, stateForm[input.name], input.validationRules);
 
             validationErrors = {
+                ...validationErrors,
                 ...validationError
             };
 


### PR DESCRIPTION
* Use validation from `validateForm` or what is passed in.
* Spread validation errors when validating form. 